### PR TITLE
Update organization references to opencadc-metadata-curation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update --no-install-recommends  && apt-get dist-upgrade -y && \
 WORKDIR /usr/src/app
 
 ARG OPENCADC_BRANCH=main
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 
 RUN git clone https://github.com/${OPENCADC_REPO}/caom2tools.git && \
     cd caom2tools && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG OPENCADC_PYTHON_VERSION=3.12
-FROM opencadc/pandas:${OPENCADC_PYTHON_VERSION}-slim AS builder
+FROM opencadc-metadata-curation/pandas:${OPENCADC_PYTHON_VERSION}-slim AS builder
 
 RUN apt-get update --no-install-recommends  && apt-get dist-upgrade -y && \
     apt-get install -y build-essential \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
 1. In the master branch of this repository, find the scripts directory, and copy the file gem_run_public.sh to the working directory. e.g.:
 
   ```
-  wget https://raw.github.com/opencadc/gem2caom2/master/scripts/gem_run_public.sh
+  wget https://raw.github.com/opencadc-metadata-curation/gem2caom2/master/scripts/gem_run_public.sh
   ```
 
 2. Ensure the script is executable:
@@ -29,7 +29,7 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
 1. In the master branch of this repository, find the scripts directory, and copy the file gem_run_incremental.sh to the working directory. e.g.:
 
   ```
-  wget https://raw.github.com/opencadc/gem2caom2/master/scripts/gem_run_incremental.sh
+  wget https://raw.github.com/opencadc-metadata-curation/gem2caom2/master/scripts/gem_run_incremental.sh
   ```
 
 2. Ensure the script is executable:

--- a/scripts/gem_run.sh
+++ b/scripts/gem_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="opencadc/gem2caom2"
+IMAGE="opencadc-metadata-curation/gem2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?

--- a/scripts/gem_run_incremental.sh
+++ b/scripts/gem_run_incremental.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="opencadc/gem2caom2"
+IMAGE="opencadc-metadata-curation/gem2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?

--- a/scripts/gem_run_public.sh
+++ b/scripts/gem_run_public.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="opencadc/gem2caom2"
+IMAGE="opencadc-metadata-curation/gem2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?

--- a/scripts/gem_run_state.sh
+++ b/scripts/gem_run_state.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="opencadc/gem2caom2"
+IMAGE="opencadc-metadata-curation/gem2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?

--- a/scripts/gem_validate.sh
+++ b/scripts/gem_validate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 COLLECTION="gem"
-IMAGE="opencadc/${COLLECTION}2caom2"
+IMAGE="opencadc-metadata-curation/${COLLECTION}2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?


### PR DESCRIPTION
This PR updates all references from `opencadc` to `opencadc-metadata-curation` following the repository transfer.

## Changes
- Updated Dockerfile dependencies and base images\n- Updated shell scripts\n
## Files Modified
```
Dockerfile
scripts/gem_run.sh
scripts/gem_run_incremental.sh
scripts/gem_run_public.sh
scripts/gem_run_state.sh
scripts/gem_validate.sh
```

## Related
- Repository migration to opencadc-metadata-curation organization
- Ensures all references point to the correct organization

## Testing
- Verify builds pass
- Verify all references are updated correctly
